### PR TITLE
Corrected ambiguity warnings in the test

### DIFF
--- a/include/Analogs.h
+++ b/include/Analogs.h
@@ -21,12 +21,6 @@ public:
     ///
     Analogs();
 
-    ///
-    /// \brief Create an empty holder for the analogous data preallocating the size of it
-    /// \param nbSubframes The number of subframes to be in the holder
-    ///
-    Analogs(size_t nbSubframes);
-
 
     //---- STREAM ----//
 public:
@@ -56,6 +50,12 @@ public:
     /// \return The number of subframes
     ///
     size_t nbSubframes() const;
+
+    ///
+    /// \brief Resize the number of subframes. Warning, this function drops data if subframes is downsized
+    /// \param nbSubframes The number of subframes to be in the holder
+    ///
+    void nbSubframes(size_t nbSubframes);
 
     ///
     /// \brief Get a particular subframe of index idx from the analogous data set

--- a/include/Subframe.h
+++ b/include/Subframe.h
@@ -21,12 +21,6 @@ public:
     ///
     SubFrame();
 
-    ///
-    /// \brief Create an empty subframe for analogous data, allocating the number of channels
-    /// \param nChannels Number of channels in the subframe
-    ///
-    SubFrame(size_t nChannels);
-
 
     //---- STREAM ----//
 public:
@@ -56,6 +50,12 @@ public:
     /// \return The number of channels
     ///
     size_t nbChannels() const;
+
+    ///
+    /// \brief Resize the number of channels. Warning, this function drops data if channels are downsized.
+    /// \param nChannels Number of channels in the subframe
+    ///
+    void nbChannels(size_t nChannels);
 
     ///
     /// \brief Get the index of a analog channel in the subframe

--- a/src/Analogs.cpp
+++ b/src/Analogs.cpp
@@ -14,11 +14,6 @@ ezc3d::DataNS::AnalogsNS::Analogs::Analogs()
 
 }
 
-ezc3d::DataNS::AnalogsNS::Analogs::Analogs(size_t nbSubframes)
-{
-    _subframe.resize(nbSubframes);
-}
-
 void ezc3d::DataNS::AnalogsNS::Analogs::print() const
 {
     for (size_t i = 0; i < nbSubframes(); ++i){
@@ -38,6 +33,11 @@ void ezc3d::DataNS::AnalogsNS::Analogs::write(std::fstream &f) const
 size_t ezc3d::DataNS::AnalogsNS::Analogs::nbSubframes() const
 {
     return _subframe.size();
+}
+
+void ezc3d::DataNS::AnalogsNS::Analogs::nbSubframes(size_t nbSubframes)
+{
+    _subframe.resize(nbSubframes);
 }
 
 const ezc3d::DataNS::AnalogsNS::SubFrame& ezc3d::DataNS::AnalogsNS::Analogs::subframe(size_t idx) const

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -58,9 +58,11 @@ ezc3d::DataNS::Data::Data(ezc3d::c3d &file)
             _frames[j].add(ptsAtAFrame); // modified by pts_tp which is an nonconst ref to internal points
 
             // Read analogs
-            ezc3d::DataNS::AnalogsNS::Analogs analog(file.header().nbAnalogByFrame());
+            ezc3d::DataNS::AnalogsNS::Analogs analog;
+            analog.nbSubframes(file.header().nbAnalogByFrame());
             for (size_t k = 0; k < file.header().nbAnalogByFrame(); ++k){
-                ezc3d::DataNS::AnalogsNS::SubFrame sub(file.header().nbAnalogs());
+                ezc3d::DataNS::AnalogsNS::SubFrame sub;
+                sub.nbChannels(file.header().nbAnalogs());
                 for (size_t i = 0; i < file.header().nbAnalogs(); ++i){
                     ezc3d::DataNS::AnalogsNS::Channel c;
                     c.data(file.readFloat());

--- a/src/Subframe.cpp
+++ b/src/Subframe.cpp
@@ -14,11 +14,6 @@ ezc3d::DataNS::AnalogsNS::SubFrame::SubFrame()
 
 }
 
-ezc3d::DataNS::AnalogsNS::SubFrame::SubFrame(size_t nChannels)
-{
-    _channels.resize(nChannels);
-}
-
 void ezc3d::DataNS::AnalogsNS::SubFrame::print() const
 {
     for (size_t i = 0; i < nbChannels(); ++i){
@@ -36,6 +31,11 @@ void ezc3d::DataNS::AnalogsNS::SubFrame::write(std::fstream &f) const
 size_t ezc3d::DataNS::AnalogsNS::SubFrame::nbChannels() const
 {
     return _channels.size();
+}
+
+void ezc3d::DataNS::AnalogsNS::SubFrame::nbChannels(size_t nChannels)
+{
+    _channels.resize(nChannels);
 }
 
 size_t ezc3d::DataNS::AnalogsNS::SubFrame::channelIdx(const std::string &channelName) const

--- a/test/test_ezc3d.cpp
+++ b/test/test_ezc3d.cpp
@@ -30,6 +30,7 @@ struct c3dTestStruct{
     size_t nFrames = SIZE_MAX;
     size_t nPoints = SIZE_MAX;
     float nSubframes = -1;
+    float dummyForByteAlignment = -1; // Because of float precision, 4 bytes must be padded here due to the odd numer of float variables
     std::vector<std::string> pointNames;
 
     size_t nAnalogs = SIZE_MAX;
@@ -705,7 +706,6 @@ TEST(c3dModifier, specificAnalog){
     EXPECT_THROW(new_c3d.c3d.analog(frames), std::invalid_argument);
 
     // Wrong number of channels
-    EXPECT_NO_THROW(ezc3d::DataNS::AnalogsNS::SubFrame(0));
     for (size_t f = 0; f < new_c3d.nFrames; ++f){
         ezc3d::DataNS::Frame frame;
         ezc3d::DataNS::AnalogsNS::Analogs analogs;
@@ -942,7 +942,8 @@ TEST(c3dModifier, addFrames){
 
     ezc3d::DataNS::Frame stupidFrameAnalog;
     ezc3d::DataNS::AnalogsNS::Analogs stupidAnalogs(new_c3d.c3d.data().frame(0).analogs());
-    ezc3d::DataNS::AnalogsNS::SubFrame stupidSubframe(new_c3d.nAnalogs-1);
+    ezc3d::DataNS::AnalogsNS::SubFrame stupidSubframe;
+    stupidSubframe.nbChannels(new_c3d.nAnalogs-1);
     stupidAnalogs.subframe(stupidSubframe);
     stupidFrameAnalog.add(stupidPoints, stupidAnalogs);
     EXPECT_THROW(new_c3d.c3d.frame(stupidFrameAnalog), std::runtime_error); // Wrong frame rate for analogs
@@ -952,7 +953,8 @@ TEST(c3dModifier, addFrames){
     new_c3d.c3d.parameter("ANALOG", analogRate);
     EXPECT_THROW(new_c3d.c3d.frame(stupidFrameAnalog), std::runtime_error);
 
-    ezc3d::DataNS::AnalogsNS::SubFrame notSoStupidSubframe(new_c3d.nAnalogs);
+    ezc3d::DataNS::AnalogsNS::SubFrame notSoStupidSubframe;
+    notSoStupidSubframe.nbChannels(new_c3d.nAnalogs);
     stupidAnalogs.subframe(notSoStupidSubframe, 0);
     stupidFrameAnalog.add(stupidPoints, stupidAnalogs);
     EXPECT_NO_THROW(new_c3d.c3d.frame(stupidFrameAnalog));


### PR DESCRIPTION
Warnings were caused by an ambiguity while creating analogs or subframes. In order to disambiguate, I removed the constructor where one could directly specify the number of channel. Now it must be done via the proper nbChannel.... function