### PR TITLE
Refactor to remove a legacy idea that c3d was a fstream

### DIFF
--- a/include/Data.h
+++ b/include/Data.h
@@ -25,9 +25,11 @@ public:
 
     ///
     /// \brief Create a filled Data class from a given file
+    /// \param c3d Reference to the c3d to copy the data in
     /// \param file File to copy the data from
     ///
-    Data(ezc3d::c3d &file);
+    Data(ezc3d::c3d &c3d,
+         std::fstream &file);
 
 
     //---- STREAM ----//

--- a/include/Group.h
+++ b/include/Group.h
@@ -41,11 +41,14 @@ public:
 
     ///
     /// \brief Read and store a group of parameter from an opened C3D file
+    /// \param c3d C3D reference to copy the data in
     /// \param file The file stream already opened with read access
     /// \param nbCharInName The number of character of the group name
     /// \return The position in the file of the next Group/Parameter
     ///
-    int read(ezc3d::c3d &file, int nbCharInName);
+    int read(ezc3d::c3d &c3d,
+             std::fstream &file,
+             int nbCharInName);
 
 
     //---- METADATA ----//
@@ -163,11 +166,14 @@ public:
 
     ///
     /// \brief Add a parameter to the group from a C3D file
+    /// \param c3d C3D reference to copy the data in
     /// \param file The file stream already opened with read access
     /// \param nbCharInName The number of character of the parameter name
     /// \return
     ///
-    int parameter(ezc3d::c3d &file, int nbCharInName);
+    int parameter(c3d &c3d,
+                  std::fstream &file,
+                  int nbCharInName);
 
     ///
     /// \brief Add/replace a parameter to the group

--- a/include/Header.h
+++ b/include/Header.h
@@ -23,9 +23,11 @@ public:
 
     ///
     /// \brief Read and store the header of an opened C3D file
+    /// \param c3d C3D reference to copy the data in
     /// \param file Already opened fstream file with read access
     ///
-    Header(ezc3d::c3d &file);
+    Header(c3d &c3d,
+           std::fstream &file);
 
 
     //---- STREAM ----//
@@ -43,9 +45,11 @@ public:
 
     ///
     /// \brief Read and store a header from an opened C3D file
+    /// \param c3d C3D reference to copy the data in
     /// \param file The file stream already opened with read access
     ///
-    void read(ezc3d::c3d &file);
+    void read(c3d &c3d,
+              std::fstream &file);
 
 
     //---- HEADER ----//

--- a/include/Parameter.h
+++ b/include/Parameter.h
@@ -55,11 +55,14 @@ protected:
 public:
     ///
     /// \brief Read and store a parameter from an opened C3D file
+    /// \param c3d C3D reference to copy the data in
     /// \param file The file stream already opened with read access
     /// \param nbCharInName The number of character of the parameter name
     /// \return The position in the file of the next Group/Parameter
     ///
-    int read(ezc3d::c3d &file, int nbCharInName);
+    int read(c3d &c3d,
+             std::fstream &file,
+             int nbCharInName);
 
 
     //---- METADATA ----//

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -23,9 +23,11 @@ public:
 
     ///
     /// \brief Construct group holder from a C3D file
+    /// \param c3d C3D reference to copy the data in
     /// \param file Already opened fstream file with read access
     ///
-    Parameters(ezc3d::c3d &file);
+    Parameters(c3d &c3d,
+               std::fstream &file);
 
 protected:
     ///

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -27,6 +27,11 @@ public:
     ///
     Parameters(ezc3d::c3d &file);
 
+protected:
+    ///
+    /// \brief Add all required parameter for a c3d to be valid
+    ///
+    void setMandatoryParameters();
 
     //---- STREAM ----//
 public:

--- a/include/ezc3d.h
+++ b/include/ezc3d.h
@@ -141,7 +141,7 @@ namespace ezc3d {
 ///
 /// \brief Main class for C3D holder
 ///
-class EZC3D_API ezc3d::c3d : public std::fstream {
+class EZC3D_API ezc3d::c3d {
 protected:
     std::string _filePath; ///< The file path if the C3D was opened from a file
 
@@ -184,12 +184,15 @@ protected:
 
     ///
     /// \brief Actual function that reads the file, it returns the value into a generic char pointer that must be pre-allocate
+    /// \param file opened file stream to be read
     /// \param nByteToRead The number of bytes to read
     /// \param c The output char
     /// \param nByteFromPrevious The number of byte to skip from current position
     /// \param pos The position to start from
     ///
-    void readFile(unsigned int nByteToRead,
+    void readFile(
+        std::fstream &file,
+        unsigned int nByteToRead,
         char * c,
         int nByteFromPrevious = 0,
         const  std::ios_base::seekdir &pos = std::ios::cur);
@@ -213,73 +216,88 @@ protected:
 public:
     ///
     /// \brief Read an integer of nByteToRead bytes at the position current + nByteFromPrevious from a file
+    /// \param file opened file stream to be read
     /// \param nByteToRead The number of byte to read to be converted into integer
     /// \param nByteFromPrevious The number of bytes to skip from the current cursor position
     /// \param pos Where to reposition the cursor
     /// \return The integer value
     ///
-    int readInt(unsigned int nByteToRead,
+    int readInt(std::fstream &file,
+                unsigned int nByteToRead,
                 int nByteFromPrevious = 0,
                 const std::ios_base::seekdir &pos = std::ios::cur);
 
     ///
     /// \brief Read a unsigned integer of nByteToRead bytes at the position current + nByteFromPrevious from a file
+    /// \param file opened file stream to be read
     /// \param nByteToRead The number of byte to read to be converted into unsigned integer
     /// \param nByteFromPrevious The number of bytes to skip from the current cursor position
     /// \param pos Where to reposition the cursor
     /// \return The unsigned integer value
     ///
-    size_t readUint(unsigned int nByteToRead,
+    size_t readUint(std::fstream &file,
+                    unsigned int nByteToRead,
                     int nByteFromPrevious = 0,
                     const std::ios_base::seekdir &pos = std::ios::cur);
 
     ///
     /// \brief Read a float at the position current + nByteFromPrevious from a file
+    /// \param file opened file stream to be read
     /// \param nByteFromPrevious The number of bytes to skip from the current cursor position
     /// \param pos Where to reposition the cursor
     /// \return The float value
     ///
-    float readFloat(int nByteFromPrevious = 0,
+    float readFloat(std::fstream &file,
+                    int nByteFromPrevious = 0,
                     const std::ios_base::seekdir &pos = std::ios::cur);
 
     ///
     /// \brief Read a string (array of char of nByteToRead bytes) at the position current + nByteFromPrevious from a file
+    /// \param file opened file stream to be read
     /// \param nByteToRead The number of byte to read to be converted into float
     /// \param nByteFromPrevious The number of bytes to skip from the current cursor position
     /// \param pos Where to reposition the cursor
     /// \return The float value
     ///
-    std::string readString(unsigned int nByteToRead,
+    std::string readString(std::fstream &file,
+                           unsigned int nByteToRead,
                            int nByteFromPrevious = 0,
                            const std::ios_base::seekdir &pos = std::ios::cur);
 
     ///
     /// \brief Read a matrix of integer parameters of dimensions dimension with each integer of length dataLengthInByte
+    /// \param file opened file stream to be read
     /// \param dataLenghtInBytes The number of bytes to read to be converted to int
     /// \param dimension The dimensions of the matrix up to 7-dimensions
     /// \param param_data The actual output of the function
     /// \param currentIdx Internal tracker of where the function is in the flow of the recursive calls
     ///
-    void readParam(unsigned int dataLenghtInBytes, const std::vector<size_t> &dimension,
-                    std::vector<int> &param_data, size_t currentIdx = 0);
+    void readParam(std::fstream &file,
+                   unsigned int dataLenghtInBytes,
+                   const std::vector<size_t> &dimension,
+                   std::vector<int> &param_data, size_t currentIdx = 0);
 
     ///
     /// \brief Read a matrix of float parameters of dimensions dimension
+    /// \param file opened file stream to be read
     /// \param dimension The dimensions of the matrix up to 7-dimensions
     /// \param param_data The actual output of the function
     /// \param currentIdx Internal tracker of where the function is in the flow of the recursive calls
     ///
-    void readParam(const std::vector<size_t> &dimension,
-                    std::vector<float> &param_data,
-                    size_t currentIdx = 0);
+    void readParam(std::fstream &file,
+                   const std::vector<size_t> &dimension,
+                   std::vector<float> &param_data,
+                   size_t currentIdx = 0);
 
     ///
     /// \brief Read a matrix of string of dimensions dimension with the first dimension being the length of the strings
+    /// \param file opened file stream to be read
     /// \param dimension The dimensions of the matrix up to 7-dimensions. The first dimension is the length of the strings
     /// \param param_data The actual output of the function
     ///
-    void readParam(const std::vector<size_t> &dimension,
-                    std::vector<std::string> &param_data);
+    void readParam(std::fstream &file,
+                   const std::vector<size_t> &dimension,
+                   std::vector<std::string> &param_data);
 
 protected:
     ///
@@ -299,11 +317,13 @@ protected:
 
     ///
     /// \brief Internal function to read a string array to a matrix of strings
+    /// \param file opened file stream to be read
     /// \param dimension The dimensions of the matrix up to 7-dimensions
     /// \param param_data The output matrix of strings
     /// \param currentIdx Internal counter to keep track where the function is in its recursive calls
     ///
-    void _readMatrix(const std::vector<size_t> &dimension,
+    void _readMatrix(std::fstream &file,
+                     const std::vector<size_t> &dimension,
                      std::vector<std::string> &param_data,
                      size_t currentIdx = 0);
 

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -14,37 +14,37 @@ ezc3d::DataNS::Data::Data()
 
 }
 
-ezc3d::DataNS::Data::Data(ezc3d::c3d &file)
+ezc3d::DataNS::Data::Data(ezc3d::c3d &c3d, std::fstream &file)
 {
     // Firstly read a dummy value just prior to the data so it moves the pointer to the right place
-    file.readInt(ezc3d::DATA_TYPE::BYTE,
-                 static_cast<int>(256*ezc3d::DATA_TYPE::WORD*(file.header().parametersAddress()-1) + file.header().nbOfZerosBeforeHeader() +
-                 256*ezc3d::DATA_TYPE::WORD*file.parameters().nbParamBlock() -
+    c3d.readInt(file, ezc3d::DATA_TYPE::BYTE,
+                 static_cast<int>(256*ezc3d::DATA_TYPE::WORD*(c3d.header().parametersAddress()-1) + c3d.header().nbOfZerosBeforeHeader() +
+                 256*ezc3d::DATA_TYPE::WORD*c3d.parameters().nbParamBlock() -
                  ezc3d::DATA_TYPE::BYTE), std::ios::beg); // "- BYTE" so it is just prior
 
     // Get names of the data
     std::vector<std::string> pointNames;
-    if (file.header().nb3dPoints() > 0)
-        pointNames = file.parameters().group("POINT").parameter("LABELS").valuesAsString();
+    if (c3d.header().nb3dPoints() > 0)
+        pointNames = c3d.parameters().group("POINT").parameter("LABELS").valuesAsString();
     std::vector<std::string> analogNames;
-    if (file.header().nbAnalogs() > 0)
-        analogNames = file.parameters().group("ANALOG").parameter("LABELS").valuesAsString();
+    if (c3d.header().nbAnalogs() > 0)
+        analogNames = c3d.parameters().group("ANALOG").parameter("LABELS").valuesAsString();
 
     // Read the actual data
-    for (size_t j = 0; j < file.header().nbFrames(); ++j){
+    for (size_t j = 0; j < c3d.header().nbFrames(); ++j){
         if (file.eof())
             break;
 
         ezc3d::DataNS::Frame f;
-        if (file.header().scaleFactor() < 0){ // if it is float
+        if (c3d.header().scaleFactor() < 0){ // if it is float
             // Read point 3d
-            ezc3d::DataNS::Points3dNS::Points ptsAtAFrame(file.header().nb3dPoints());
-            for (size_t i = 0; i < file.header().nb3dPoints(); ++i){
+            ezc3d::DataNS::Points3dNS::Points ptsAtAFrame(c3d.header().nb3dPoints());
+            for (size_t i = 0; i < c3d.header().nb3dPoints(); ++i){
                 ezc3d::DataNS::Points3dNS::Point pt;
-                pt.x(file.readFloat());
-                pt.y(file.readFloat());
-                pt.z(file.readFloat());
-                pt.residual(file.readFloat());
+                pt.x(c3d.readFloat(file));
+                pt.y(c3d.readFloat(file));
+                pt.z(c3d.readFloat(file));
+                pt.residual(c3d.readFloat(file));
                 if (i < pointNames.size())
                     pt.name(pointNames[i]);
                 else {
@@ -58,13 +58,13 @@ ezc3d::DataNS::Data::Data(ezc3d::c3d &file)
 
             // Read analogs
             ezc3d::DataNS::AnalogsNS::Analogs analog;
-            analog.nbSubframes(file.header().nbAnalogByFrame());
-            for (size_t k = 0; k < file.header().nbAnalogByFrame(); ++k){
+            analog.nbSubframes(c3d.header().nbAnalogByFrame());
+            for (size_t k = 0; k < c3d.header().nbAnalogByFrame(); ++k){
                 ezc3d::DataNS::AnalogsNS::SubFrame sub;
-                sub.nbChannels(file.header().nbAnalogs());
-                for (size_t i = 0; i < file.header().nbAnalogs(); ++i){
+                sub.nbChannels(c3d.header().nbAnalogs());
+                for (size_t i = 0; i < c3d.header().nbAnalogs(); ++i){
                     ezc3d::DataNS::AnalogsNS::Channel c;
-                    c.data(file.readFloat());
+                    c.data(c3d.readFloat(file));
                     if (i < analogNames.size())
                         c.name(analogNames[i]);
                     else {

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -61,7 +61,7 @@ void ezc3d::ParametersNS::GroupNS::Group::write(std::fstream &f, int groupIdx, s
 
 }
 
-int ezc3d::ParametersNS::GroupNS::Group::read(ezc3d::c3d &file, int nbCharInName)
+int ezc3d::ParametersNS::GroupNS::Group::read(ezc3d::c3d &c3d, std::fstream &file, int nbCharInName)
 {
     if (nbCharInName < 0)
         _isLocked = true;
@@ -69,10 +69,10 @@ int ezc3d::ParametersNS::GroupNS::Group::read(ezc3d::c3d &file, int nbCharInName
         _isLocked = false;
 
     // Read name of the group
-    _name.assign(file.readString(static_cast<unsigned int>(abs(nbCharInName) * ezc3d::DATA_TYPE::BYTE)));
+    _name.assign(c3d.readString(file, static_cast<unsigned int>(abs(nbCharInName) * ezc3d::DATA_TYPE::BYTE)));
 
     // number of byte to the next group from here
-    size_t offsetNext(file.readUint(2*ezc3d::DATA_TYPE::BYTE));
+    size_t offsetNext(c3d.readUint(file, 2*ezc3d::DATA_TYPE::BYTE));
     // Compute the position of the element in the file
     int nextParamByteInFile;
     if (offsetNext == 0)
@@ -81,10 +81,10 @@ int ezc3d::ParametersNS::GroupNS::Group::read(ezc3d::c3d &file, int nbCharInName
         nextParamByteInFile = static_cast<int>(static_cast<size_t>(file.tellg()) + offsetNext - ezc3d::DATA_TYPE::WORD);
 
     // Byte 5+nbCharInName ==> Number of characters in group description
-    int nbCharInDesc(file.readInt(1*ezc3d::DATA_TYPE::BYTE));
+    int nbCharInDesc(c3d.readInt(file, 1*ezc3d::DATA_TYPE::BYTE));
     // Byte 6+nbCharInName ==> Group description
     if (nbCharInDesc)
-        _description = file.readString(static_cast<unsigned int>(nbCharInDesc));
+        _description = c3d.readString(file, static_cast<unsigned int>(nbCharInDesc));
 
     // Return how many bytes
     return nextParamByteInFile;
@@ -172,10 +172,10 @@ ezc3d::ParametersNS::GroupNS::Parameter &ezc3d::ParametersNS::GroupNS::Group::pa
     return parameter_nonConst(parameterIdx(parameterName));
 }
 
-int ezc3d::ParametersNS::GroupNS::Group::parameter(ezc3d::c3d &file, int nbCharInName)
+int ezc3d::ParametersNS::GroupNS::Group::parameter(ezc3d::c3d &c3d, std::fstream &file, int nbCharInName)
 {
     ezc3d::ParametersNS::GroupNS::Parameter p;
-    int nextParamByteInFile = p.read(file, nbCharInName);
+    int nextParamByteInFile = p.read(c3d, file, nbCharInName);
     parameter(p);
     return nextParamByteInFile;
 }

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -139,7 +139,7 @@ void ezc3d::ParametersNS::Parameters::setMandatoryParameters()
         }
         {
             ezc3d::ParametersNS::GroupNS::Parameter p("GEN_SCALE", "");
-            p.set(1);
+            p.set(1.0);
             grp.parameter(p);
         }
         {

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -15,6 +15,60 @@ ezc3d::ParametersNS::Parameters::Parameters():
     _nbParamBlock(0),
     _processorType(84)
 {
+    setMandatoryParameters();
+}
+
+ezc3d::ParametersNS::Parameters::Parameters(ezc3d::c3d &file) :
+    _parametersStart(0),
+    _checksum(0),
+    _nbParamBlock(0),
+    _processorType(0)
+{
+    setMandatoryParameters();
+
+    // Read the Parameters Header
+    _parametersStart = file.readUint(1*ezc3d::DATA_TYPE::BYTE, static_cast<int>(256*ezc3d::DATA_TYPE::WORD*(file.header().parametersAddress()-1) + file.header().nbOfZerosBeforeHeader()), std::ios::beg);
+    _checksum = file.readUint(1*ezc3d::DATA_TYPE::BYTE);
+    _nbParamBlock = file.readUint(1*ezc3d::DATA_TYPE::BYTE);
+    _processorType = file.readUint(1*ezc3d::DATA_TYPE::BYTE);
+    if (_checksum == 0 && _parametersStart == 0){
+        // In theory, if this happens, this is a bad c3d formatting and should return an error, but for some reason
+        // Qualisys decided that they would not comply to the standard. Therefore set put "_parameterStart" and "_checksum" to 0
+        // This is a patch for Qualisys bad formatting c3d
+        _parametersStart = 1;
+        _checksum = 0x50;
+    }
+    if (_checksum != 0x50) // If checkbyte is wrong
+        throw std::ios_base::failure("File must be a valid c3d file");
+
+    // Read parameter or group
+    std::streampos nextParamByteInFile(static_cast<int>(file.tellg()) + static_cast<int>(_parametersStart) - ezc3d::DATA_TYPE::BYTE);
+    while (nextParamByteInFile)
+    {
+        // Check if we spontaneously got to the next parameter. Otherwise c3d is messed up
+        if (file.tellg() != nextParamByteInFile)
+            throw std::ios_base::failure("Bad c3d formatting");
+
+        // Nb of char in the group name, locked if negative, 0 if we finished the section
+        int nbCharInName(file.readInt(1*ezc3d::DATA_TYPE::BYTE));
+        if (nbCharInName == 0)
+            break;
+        int id(file.readInt(1*ezc3d::DATA_TYPE::BYTE));
+
+        // Make sure there at least enough group
+        for (size_t i = _groups.size(); i < static_cast<size_t>(abs(id)); ++i)
+            _groups.push_back(ezc3d::ParametersNS::GroupNS::Group());
+
+        // Group ID always negative for groups and positive parameter of group ID
+        if (id < 0)
+            nextParamByteInFile = group_nonConst(static_cast<size_t>(abs(id)-1)).read(file, nbCharInName);
+        else
+            nextParamByteInFile = group_nonConst(static_cast<size_t>(id-1)).parameter(file, nbCharInName);
+    }
+}
+
+void ezc3d::ParametersNS::Parameters::setMandatoryParameters()
+{
     // Mandatory groups
     {
         ezc3d::ParametersNS::GroupNS::Group grp("POINT", "");
@@ -159,53 +213,6 @@ ezc3d::ParametersNS::Parameters::Parameters():
             grp.parameter(p);
         }
         group(grp);
-    }
-}
-
-ezc3d::ParametersNS::Parameters::Parameters(ezc3d::c3d &file) :
-    _parametersStart(0),
-    _checksum(0),
-    _nbParamBlock(0),
-    _processorType(0)
-{
-    // Read the Parameters Header
-    _parametersStart = file.readUint(1*ezc3d::DATA_TYPE::BYTE, static_cast<int>(256*ezc3d::DATA_TYPE::WORD*(file.header().parametersAddress()-1) + file.header().nbOfZerosBeforeHeader()), std::ios::beg);
-    _checksum = file.readUint(1*ezc3d::DATA_TYPE::BYTE);
-    _nbParamBlock = file.readUint(1*ezc3d::DATA_TYPE::BYTE);
-    _processorType = file.readUint(1*ezc3d::DATA_TYPE::BYTE);
-    if (_checksum == 0 && _parametersStart == 0){
-        // Theoritically, if this happens, this is a bad c3d formatting and should return an error, but for some reason
-        // Qualisys decided that they would not comply to the standard. Therefore they put "_parameterStart" and "_checksum" to 0
-        // This is a patch for Qualisys bad formatting c3d
-        _parametersStart = 1;
-        _checksum = 0x50;
-    }
-    if (_checksum != 0x50) // If checkbyte is wrong
-        throw std::ios_base::failure("File must be a valid c3d file");
-
-    // Read parameter or group
-    std::streampos nextParamByteInFile(static_cast<int>(file.tellg()) + static_cast<int>(_parametersStart) - ezc3d::DATA_TYPE::BYTE);
-    while (nextParamByteInFile)
-    {
-        // Check if we spontaneously got to the next parameter. Otherwise c3d is messed up
-        if (file.tellg() != nextParamByteInFile)
-            throw std::ios_base::failure("Bad c3d formatting");
-
-        // Nb of char in the group name, locked if negative, 0 if we finished the section
-        int nbCharInName(file.readInt(1*ezc3d::DATA_TYPE::BYTE));
-        if (nbCharInName == 0)
-            break;
-        int id(file.readInt(1*ezc3d::DATA_TYPE::BYTE));
-
-        // Make sure there at least enough group
-        for (size_t i = _groups.size(); i < static_cast<size_t>(abs(id)); ++i)
-            _groups.push_back(ezc3d::ParametersNS::GroupNS::Group());
-
-        // Group ID always negative for groups and positive parameter of group ID
-        if (id < 0)
-            nextParamByteInFile = group_nonConst(static_cast<size_t>(abs(id)-1)).read(file, nbCharInName);
-        else
-            nextParamByteInFile = group_nonConst(static_cast<size_t>(id-1)).parameter(file, nbCharInName);
     }
 }
 

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -435,15 +435,12 @@ void ezc3d::c3d::updateHeader()
         if (data().frame(0).analogs().nbSubframes() != static_cast<size_t>(header().nbAnalogByFrame()))
             _header->nbAnalogByFrame(data().frame(0).analogs().nbSubframes());
     } else {
-        // Should always be greater than 0, but we have to take in account Optotrak lazyness
-        if (parameters().group("ANALOG").nbParameters()){
-            if (static_cast<size_t>(pointRate) == 0){
-                if (static_cast<size_t>(header().nbAnalogByFrame()) != 1)
-                    _header->nbAnalogByFrame(1);
-            } else {
-                if (static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate)  != static_cast<size_t>(header().nbAnalogByFrame()))
-                    _header->nbAnalogByFrame(static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate));
-            }
+        if (static_cast<size_t>(pointRate) == 0){
+            if (static_cast<size_t>(header().nbAnalogByFrame()) != 1)
+                _header->nbAnalogByFrame(1);
+        } else {
+            if (static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate)  != static_cast<size_t>(header().nbAnalogByFrame()))
+                _header->nbAnalogByFrame(static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate));
         }
     }
 

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -441,18 +441,8 @@ void ezc3d::c3d::updateHeader()
                 if (static_cast<size_t>(header().nbAnalogByFrame()) != 1)
                     _header->nbAnalogByFrame(1);
             } else {
-                size_t analogRateIdx(SIZE_MAX);
-                try {
-                    // Take account for XSens lazyness
-                    analogRateIdx = parameters().group("ANALOG").parameterIdx("RATE");
-                } catch (const std::invalid_argument& e){
-                    // If we don't find ANALOG:RATE but ANALOG:USED is to true, throw anyway
-                    if (parameters().group("ANALOG").parameter("USED").valuesAsInt()[0])
-                        throw e;
-                }
-                if (analogRateIdx != SIZE_MAX)
-                    if (static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate)  != static_cast<size_t>(header().nbAnalogByFrame()))
-                        _header->nbAnalogByFrame(static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate));
+                if (static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate)  != static_cast<size_t>(header().nbAnalogByFrame()))
+                    _header->nbAnalogByFrame(static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate));
             }
         }
     }

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -444,12 +444,8 @@ void ezc3d::c3d::updateHeader()
         }
     }
 
-    // Should always be greater than 0, but we have to take in account Optotrak lazyness
-    if (parameters().group("ANALOG").nbParameters()){
-        if (static_cast<size_t>(parameters().group("ANALOG").parameter("USED").valuesAsInt()[0]) != header().nbAnalogs())
-            _header->nbAnalogs(static_cast<size_t>(parameters().group("ANALOG").parameter("USED").valuesAsInt()[0]));
-    } else
-        _header->nbAnalogs(0);
+    if (static_cast<size_t>(parameters().group("ANALOG").parameter("USED").valuesAsInt()[0]) != header().nbAnalogs())
+        _header->nbAnalogs(static_cast<size_t>(parameters().group("ANALOG").parameter("USED").valuesAsInt()[0]));
 }
 
 void ezc3d::c3d::updateParameters(const std::vector<std::string> &newPoints, const std::vector<std::string> &newAnalogs)

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -36,30 +36,30 @@ ezc3d::c3d::c3d():
 }
 
 ezc3d::c3d::c3d(const std::string &filePath):
-    std::fstream(filePath, std::ios::in | std::ios::binary),
     _filePath(filePath),
     m_nByteToRead_float(4*ezc3d::DATA_TYPE::BYTE)
 {
+    std::fstream stream(_filePath, std::ios::in | std::ios::binary);
     c_float = new char[m_nByteToRead_float + 1];
 
-    if (!is_open())
+    if (!stream.is_open())
         throw std::ios_base::failure("Could not open the c3d file");
 
     // Read all the section
-    _header = std::shared_ptr<ezc3d::Header>(new ezc3d::Header(*this));
-    _parameters = std::shared_ptr<ezc3d::ParametersNS::Parameters>(new ezc3d::ParametersNS::Parameters(*this));
+    _header = std::shared_ptr<ezc3d::Header>(new ezc3d::Header(*this, stream));
+    _parameters = std::shared_ptr<ezc3d::ParametersNS::Parameters>(new ezc3d::ParametersNS::Parameters(*this, stream));
 
     // header may be inconsistent with the parameters, so it must be update to make sure sizes are consistent
     updateHeader();
 
     // Now read the actual data
-    _data = std::shared_ptr<ezc3d::DataNS::Data>(new ezc3d::DataNS::Data(*this));
+    _data = std::shared_ptr<ezc3d::DataNS::Data>(new ezc3d::DataNS::Data(*this, stream));
 
     // Parameters and header may be inconsistent with actual data, so reprocess them if needed
     updateParameters();
 
     // Close the file
-    close();
+    stream.close();
 }
 
 ezc3d::c3d::~c3d()
@@ -98,12 +98,12 @@ void ezc3d::c3d::write(const std::string& filePath) const
     f.close();
 }
 
-void ezc3d::c3d::readFile(unsigned int nByteToRead, char * c, int nByteFromPrevious,
+void ezc3d::c3d::readFile(std::fstream &file, unsigned int nByteToRead, char * c, int nByteFromPrevious,
                      const  std::ios_base::seekdir &pos)
 {
     if (pos != 1)
-        this->seekg (nByteFromPrevious, pos); // Move to number analogs
-    this->read (c, nByteToRead);
+        file.seekg (nByteFromPrevious, pos); // Move to number analogs
+    file.read (c, nByteToRead);
     c[nByteToRead] = '\0'; // Make sure last char is NULL
 }
 
@@ -133,11 +133,11 @@ int ezc3d::c3d::hex2int(const char * val, unsigned int len){
     return out;
 }
 
-int ezc3d::c3d::readInt(unsigned int nByteToRead, int nByteFromPrevious,
+int ezc3d::c3d::readInt(std::fstream &file, unsigned int nByteToRead, int nByteFromPrevious,
             const std::ios_base::seekdir &pos)
 {
     char* c = new char[nByteToRead + 1];
-    readFile(nByteToRead, c, nByteFromPrevious, pos);
+    readFile(file, nByteToRead, c, nByteFromPrevious, pos);
 
     // make sure it is an int and not an unsigned int
     int out(hex2int(c, nByteToRead));
@@ -145,11 +145,11 @@ int ezc3d::c3d::readInt(unsigned int nByteToRead, int nByteFromPrevious,
     return out;
 }
 
-size_t ezc3d::c3d::readUint(unsigned int nByteToRead, int nByteFromPrevious,
+size_t ezc3d::c3d::readUint(std::fstream &file, unsigned int nByteToRead, int nByteFromPrevious,
             const std::ios_base::seekdir &pos)
 {
     char* c = new char[nByteToRead + 1];
-    readFile(nByteToRead, c, nByteFromPrevious, pos);
+    readFile(file, nByteToRead, c, nByteFromPrevious, pos);
 
     // make sure it is an int and not an unsigned int
     size_t out(hex2uint(c, nByteToRead));
@@ -157,49 +157,49 @@ size_t ezc3d::c3d::readUint(unsigned int nByteToRead, int nByteFromPrevious,
     return out;
 }
 
-float ezc3d::c3d::readFloat(int nByteFromPrevious,
+float ezc3d::c3d::readFloat(std::fstream &file, int nByteFromPrevious,
                 const std::ios_base::seekdir &pos)
 {
-    readFile(m_nByteToRead_float, c_float, nByteFromPrevious, pos);
+    readFile(file, m_nByteToRead_float, c_float, nByteFromPrevious, pos);
     float out (*reinterpret_cast<float*>(c_float));
     return out;
 }
 
-std::string ezc3d::c3d::readString(unsigned int nByteToRead, int nByteFromPrevious,
+std::string ezc3d::c3d::readString(std::fstream &file, unsigned int nByteToRead, int nByteFromPrevious,
                               const std::ios_base::seekdir &pos)
 {
     char* c = new char[nByteToRead + 1];
-    readFile(nByteToRead, c, nByteFromPrevious, pos);
+    readFile(file, nByteToRead, c, nByteFromPrevious, pos);
     std::string out(c);
     delete[] c;
     return out;
 }
 
-void ezc3d::c3d::readParam(unsigned int dataLenghtInBytes, const std::vector<size_t> &dimension,
+void ezc3d::c3d::readParam(std::fstream &file, unsigned int dataLenghtInBytes, const std::vector<size_t> &dimension,
                        std::vector<int> &param_data, size_t currentIdx)
 {
     for (size_t i = 0; i < dimension[currentIdx]; ++i)
         if (currentIdx == dimension.size()-1)
-            param_data.push_back (readInt(dataLenghtInBytes*ezc3d::DATA_TYPE::BYTE));
+            param_data.push_back (readInt(file, dataLenghtInBytes*ezc3d::DATA_TYPE::BYTE));
         else
-            readParam(dataLenghtInBytes, dimension, param_data, currentIdx + 1);
+            readParam(file, dataLenghtInBytes, dimension, param_data, currentIdx + 1);
 }
 
-void ezc3d::c3d::readParam(const std::vector<size_t> &dimension,
+void ezc3d::c3d::readParam(std::fstream &file, const std::vector<size_t> &dimension,
                        std::vector<float> &param_data, size_t currentIdx)
 {
     for (size_t i = 0; i < dimension[currentIdx]; ++i)
         if (currentIdx == dimension.size()-1)
-            param_data.push_back (readFloat());
+            param_data.push_back (readFloat(file));
         else
-            readParam(dimension, param_data, currentIdx + 1);
+            readParam(file, dimension, param_data, currentIdx + 1);
 }
 
-void ezc3d::c3d::readParam(const std::vector<size_t> &dimension,
+void ezc3d::c3d::readParam(std::fstream &file, const std::vector<size_t> &dimension,
                        std::vector<std::string> &param_data_string)
 {
     std::vector<std::string> param_data_string_tp;
-    _readMatrix(dimension, param_data_string_tp);
+    _readMatrix(file, dimension, param_data_string_tp);
 
     // Vicon c3d stores text length on first dimension, I am not sure if
     // this is a standard or a custom made stuff. I implemented it like that for now
@@ -236,14 +236,14 @@ size_t ezc3d::c3d::_dispatchMatrix(const std::vector<size_t> &dimension,
     return idxInParam;
 }
 
-void ezc3d::c3d::_readMatrix(const std::vector<size_t> &dimension,
+void ezc3d::c3d::_readMatrix(std::fstream &file, const std::vector<size_t> &dimension,
                        std::vector<std::string> &param_data, size_t currentIdx)
 {
     for (size_t i = 0; i < dimension[currentIdx]; ++i)
         if (currentIdx == dimension.size()-1)
-            param_data.push_back(readString(ezc3d::DATA_TYPE::BYTE));
+            param_data.push_back(readString(file, ezc3d::DATA_TYPE::BYTE));
         else
-            _readMatrix(dimension, param_data, currentIdx + 1);
+            _readMatrix(file, dimension, param_data, currentIdx + 1);
 }
 
 const ezc3d::Header& ezc3d::c3d::header() const

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -441,8 +441,18 @@ void ezc3d::c3d::updateHeader()
                 if (static_cast<size_t>(header().nbAnalogByFrame()) != 1)
                     _header->nbAnalogByFrame(1);
             } else {
-                if (static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate)  != static_cast<size_t>(header().nbAnalogByFrame()))
-                    _header->nbAnalogByFrame(static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate));
+                size_t analogRateIdx(SIZE_MAX);
+                try {
+                    // Take account for XSens lazyness
+                    analogRateIdx = parameters().group("ANALOG").parameterIdx("RATE");
+                } catch (const std::invalid_argument& e){
+                    // If we don't find ANALOG:RATE but ANALOG:USED is to true, throw anyway
+                    if (parameters().group("ANALOG").parameter("USED").valuesAsInt()[0])
+                        throw e;
+                }
+                if (analogRateIdx != SIZE_MAX)
+                    if (static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate)  != static_cast<size_t>(header().nbAnalogByFrame()))
+                        _header->nbAnalogByFrame(static_cast<size_t>(parameters().group("ANALOG").parameter("RATE").valuesAsFloat()[0] / pointRate));
             }
         }
     }

--- a/test/test_ezc3d.cpp
+++ b/test/test_ezc3d.cpp
@@ -684,6 +684,10 @@ TEST(c3dModifier, addAnalogs) {
                                 static_cast<float>(2*f+3*sf+4*c+1) / static_cast<float>(7.0));
 }
 
+TEST(c3dModifier, removeAnalog){
+    // Remove some analog parameter, while making sure the C3D is still valid
+    // TODO when removing analog is ready
+}
 
 TEST(c3dModifier, specificAnalog){
     // Create an empty c3d

--- a/test/test_ezc3d.cpp
+++ b/test/test_ezc3d.cpp
@@ -207,9 +207,9 @@ void defaultParametersTest(const ezc3d::c3d& new_c3d, PARAMETER_TYPE type){
         EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("LABELS").valuesAsString().size(), 0);
         EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").type(), ezc3d::CHAR);
         EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").valuesAsString().size(), 0);
-        EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::INT);
-        EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt().size(), 1);
-        EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt()[0], 1);
+        EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::FLOAT);
+        EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat().size(), 1);
+        EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat()[0], 1);
         EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("SCALE").type(), ezc3d::FLOAT);
         EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("SCALE").valuesAsFloat().size(), 0);
         EXPECT_EQ(new_c3d.parameters().group("ANALOG").parameter("OFFSET").type(), ezc3d::INT);
@@ -651,9 +651,9 @@ TEST(c3dModifier, addAnalogs) {
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("LABELS").valuesAsString().size(), new_c3d.nAnalogs);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").type(), ezc3d::CHAR);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").valuesAsString().size(), new_c3d.nAnalogs);
-    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::INT);
-    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt().size(), 1);
-    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt()[0], 1);
+    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::FLOAT);
+    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat().size(), 1);
+    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat()[0], 1);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("SCALE").type(), ezc3d::FLOAT);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("SCALE").valuesAsFloat().size(), new_c3d.nAnalogs);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("OFFSET").type(), ezc3d::INT);
@@ -861,9 +861,9 @@ TEST(c3dModifier, addPointsAndAnalogs){
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("LABELS").valuesAsString().size(), new_c3d.nAnalogs);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").type(), ezc3d::CHAR);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").valuesAsString().size(), new_c3d.nAnalogs);
-    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::INT);
-    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt().size(), 1);
-    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt()[0], 1);
+    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::FLOAT);
+    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat().size(), 1);
+    EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat()[0], 1);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("SCALE").type(), ezc3d::FLOAT);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("SCALE").valuesAsFloat().size(), new_c3d.nAnalogs);
     EXPECT_EQ(new_c3d.c3d.parameters().group("ANALOG").parameter("OFFSET").type(), ezc3d::INT);
@@ -1147,9 +1147,9 @@ TEST(c3dFileIO, CreateWriteAndReadBack){
     EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("LABELS").valuesAsString().size(), ref_c3d.nAnalogs);
     EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").type(), ezc3d::CHAR);
     EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("DESCRIPTIONS").valuesAsString().size(), ref_c3d.nAnalogs);
-    EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::INT);
-    EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt().size(), 1);
-    EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsInt()[0], 1);
+    EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").type(), ezc3d::FLOAT);
+    EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat().size(), 1);
+    EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("GEN_SCALE").valuesAsFloat()[0], 1);
     EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("SCALE").type(), ezc3d::FLOAT);
     EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("SCALE").valuesAsFloat().size(), ref_c3d.nAnalogs);
     EXPECT_EQ(read_c3d.parameters().group("ANALOG").parameter("OFFSET").type(), ezc3d::INT);
@@ -1504,9 +1504,8 @@ TEST(c3dFileIO, readOptotrakC3D){
     EXPECT_EQ(Optotrak.parameters().group("POINT").parameter("UNITS").type(), ezc3d::CHAR);
     EXPECT_EQ(Optotrak.parameters().group("POINT").parameter("UNITS").valuesAsString().size(), 54);
 
-    EXPECT_EQ(Optotrak.parameters().group("FORCE_PLATFORM").parameter("USED").type(), ezc3d::INT);
-    EXPECT_EQ(Optotrak.parameters().group("FORCE_PLATFORM").parameter("USED").valuesAsInt().size(), 1);
-    EXPECT_EQ(Optotrak.parameters().group("FORCE_PLATFORM").parameter("USED").valuesAsInt()[0], 0);
+    defaultParametersTest(Optotrak, PARAMETER_TYPE::ANALOG);
+    defaultParametersTest(Optotrak, PARAMETER_TYPE::FORCE_PLATFORM);
 
     // DATA
     for (size_t f = 0; f < 30; ++f)


### PR DESCRIPTION
Having a c3d being a fstream doesn't make much sense anymore since it does way more than that now. Reading functions have been modified accordingly