### PR TITLE
JOSS recommandation on bibtex entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,13 @@ Moreover, as stated before, some (all?) companies were pretty loose in their imp
 # Cite
 If you use EZC3D, we would be grateful if you could cite it as follows:
 
-```
-@misc{Michaud2018ezc3d,
-    author = {Michaud, Benjamin and Begon, Mickael},
-    title = {EZC3D: Easy to use C3D reader/writer in C++, Python and Matlab},
-    howpublished={Web page},
-    url = {https://github.com/pyomeca/ezc3d},
-    year = {2018}
+```bibtex
+@misc{ezc3d,
+  author = {Michaud, Benjamin and Begon, Mickael},
+  title = {EZC3D: Easy to use C3D reader/writer in C++, Python and Matlab},
+  year = {2020},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  url = {https://github.com/pyomeca/ezc3d}
 }
 ```


### PR DESCRIPTION
I changed the bibtex entry to meet the [JOSS recommendations](https://joss.readthedocs.io/en/latest/submitting.html#example-paper-and-bibliography):

> If you want to cite a software repository URL (e.g. something on GitHub without a preferred
citation) then you can do it with the example BibTeX entry below for @fidgit.
```bibtex
@misc{fidgit,
  author = {​A. Smith},
  title = {Fidgit: An ungodly union of GitHub and Figshare},
  year = {2020},
  publisher = {​GitHub},
  journal = {​GitHub repository},
  url = {​https://github.com/arfon/fidgit}
}
```

I'll use this one in the pyomeca paper.