### PR TITLE
Speed up writing C3D-files from python

### DIFF
--- a/binding/python3/CMakeLists.txt
+++ b/binding/python3/CMakeLists.txt
@@ -40,7 +40,6 @@ SWIG_ADD_LIBRARY(${PROJECT_NAME}
 )
 swig_link_libraries(${PROJECT_NAME}
     "${EZC3D_NAME}"
-    "${Python3_LIBRARIES}"
 )
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")

--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -567,22 +567,8 @@ class c3d(C3dMapper):
         for i in range(nb_analog_subframes):
             analogs.subframe(subframe)
 
-        # Fill the data
-        for f in range(nb_frames):
-            for i in range(nb_points):
-                pt.set(data_points[0, i, f], data_points[1, i, f], data_points[2, i, f])
-                pt.residual(data_meta_points["residuals"][0, i, f])
-                pt.cameraMask(data_meta_points["camera_masks"][:, i, f].tolist())
-                pts.point(pt, i)
-
-            for sf in range(nb_analog_subframes):
-                for i in range(nb_analogs):
-                    c.data(data_analogs[0, i, nb_analog_subframes * f + sf])
-                    subframe.channel(c, i)
-                analogs.subframe(subframe, sf)
-            frame = ezc3d.Frame()
-            frame.add(pts, analogs)
-            new_c3d.frame(frame)
+        # # Fill the data
+        new_c3d.numpy_data(data_points, data_meta_points["residuals"], data_meta_points["camera_masks"], data_analogs)
 
         # Write the file
         new_c3d.write(path)

--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -568,7 +568,7 @@ class c3d(C3dMapper):
             analogs.subframe(subframe)
 
         # # Fill the data
-        new_c3d.numpy_data(data_points, data_meta_points["residuals"], data_meta_points["camera_masks"], data_analogs)
+        new_c3d.import_numpy_data(data_points, data_meta_points["residuals"], data_meta_points["camera_masks"], data_analogs)
 
         # Write the file
         new_c3d.write(path)

--- a/binding/python3/ezc3d_python.i
+++ b/binding/python3/ezc3d_python.i
@@ -171,7 +171,7 @@ PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
 %}
 
 %inline %{
-    void _numpy_data(ezc3d::c3d *self, PyArrayObject *pointsData, PyArrayObject *residualsData, PyArrayObject* cameraMasksData, PyArrayObject *analogData){
+    void _import_numpy_data(ezc3d::c3d *self, PyArrayObject *pointsData, PyArrayObject *residualsData, PyArrayObject* cameraMasksData, PyArrayObject *analogData){
         const size_t nbFrames = PyArray_DIM(pointsData, 2);
         const size_t nbPoints = PyArray_DIM(pointsData, 1);
         const size_t nbAnalog = PyArray_DIM(analogData, 1);
@@ -226,12 +226,12 @@ PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
 {
 
     // Extend c3d class to "import" data from numpy-arrays into object efficiently
-    void numpy_data(PyObject *pointsData, PyObject *residualsData, PyObject *cameraMasksData, PyObject *analogData){
+    void import_numpy_data(PyObject *pointsData, PyObject *residualsData, PyObject *cameraMasksData, PyObject *analogData){
         PyArrayObject *pointsDataArr = helper_getPyArrayObject(pointsData, NPY_DOUBLE);
         PyArrayObject *residualsDataArr = helper_getPyArrayObject(residualsData, NPY_DOUBLE);
         PyArrayObject *cameraMasksDataArr = helper_getPyArrayObject(cameraMasksData, NPY_DOUBLE);
         PyArrayObject *analogDataArr = helper_getPyArrayObject(analogData, NPY_DOUBLE);
-        _numpy_data(self, pointsDataArr, residualsDataArr, cameraMasksDataArr, analogDataArr);
+        _import_numpy_data(self, pointsDataArr, residualsDataArr, cameraMasksDataArr, analogDataArr);
     }
 
     // Extend c3d class to get an easy accessor to data points

--- a/binding/python3/ezc3d_python.i
+++ b/binding/python3/ezc3d_python.i
@@ -8,6 +8,7 @@
 %}
 
 %include "numpy.i"
+%fragment("NumPy_Fragments");
 %init %{
     import_array();
 %}
@@ -147,8 +148,92 @@ PyObject * _get_analogs(const ezc3d::c3d& c3d, const std::vector<int>& analogs)
 }
 %}
 
+%inline %{
+PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
+  PyArrayObject *obj;
+
+  if (PyArray_Check( input )) {
+    obj = (PyArrayObject *) input;
+    // RO - read-only
+    if (!PyArray_ISBEHAVED_RO( obj )) {
+      PyErr_SetString( PyExc_TypeError, "not algned or not in machine byte order" );
+      return NULL;
+    }
+    int conversion_done = 0;
+    obj = (PyArrayObject *) obj_to_array_allow_conversion( input, type, &conversion_done );
+    if (!obj) return NULL;
+  } else {
+    PyErr_SetString( PyExc_TypeError, "not an array" );
+    return NULL;
+  }
+  return obj;
+}
+%}
+
+%inline %{
+    void _numpy_data(ezc3d::c3d *self, PyArrayObject *pointsData, PyArrayObject *residualsData, PyArrayObject* cameraMasksData, PyArrayObject *analogData){
+        const size_t nbFrames = PyArray_DIM(pointsData, 2);
+        const size_t nbPoints = PyArray_DIM(pointsData, 1);
+        const size_t nbAnalog = PyArray_DIM(analogData, 1);
+        const size_t nbAnalogFrames = PyArray_DIM(analogData, 2);
+        const size_t nbAnalogSubframes = nbAnalogFrames / nbFrames;
+
+        ezc3d::DataNS::Points3dNS::Points pts;
+        ezc3d::DataNS::Points3dNS::Point pt;
+
+        ezc3d::DataNS::AnalogsNS::Channel c;
+        ezc3d::DataNS::AnalogsNS::SubFrame subframe;
+        ezc3d::DataNS::AnalogsNS::Analogs analogs;
+
+        ezc3d::DataNS::Frame currFrame;
+
+        for(size_t f = 0; f < nbFrames; ++f){
+            for(size_t i = 0; i < nbPoints; ++i){
+                const double x = *static_cast<double*>(PyArray_GETPTR3(pointsData, 0, i, f));
+                const double y = *static_cast<double*>(PyArray_GETPTR3(pointsData, 1, i, f));
+                const double z = *static_cast<double*>(PyArray_GETPTR3(pointsData, 2, i, f));
+                pt.set(x, y, z);
+
+                const double res = *static_cast<double*>(PyArray_GETPTR3(residualsData, 0, i, f));
+                pt.residual(res);
+
+                std::vector<bool> cameraMask;
+                for(int j = 0; j < 7; ++j){
+                    const int cam = *static_cast<int*>(PyArray_GETPTR3(cameraMasksData, j, i, f));
+                    cameraMask.push_back(cam != 0);
+                }   
+
+                pt.cameraMask(cameraMask);
+                pts.point(pt, i);
+            }
+
+            for(size_t sf = 0; sf < nbAnalogSubframes; ++sf){
+                for(size_t i = 0; i < nbAnalog; ++i){
+                    double data = *static_cast<double*>(PyArray_GETPTR3(analogData, 0, i, nbAnalogSubframes * f + sf));
+                    c.data(data);
+                    subframe.channel(c, i);
+                }
+                analogs.subframe(subframe, sf);
+            }
+
+            currFrame.add(pts, analogs);
+            self->frame(currFrame);
+        }
+    }
+%}
+
 %extend ezc3d::c3d
 {
+
+    // Extend c3d class to "import" data from numpy-arrays into object efficiently
+    void numpy_data(PyObject *pointsData, PyObject *residualsData, PyObject *cameraMasksData, PyObject *analogData){
+        PyArrayObject *pointsDataArr = helper_getPyArrayObject(pointsData, NPY_DOUBLE);
+        PyArrayObject *residualsDataArr = helper_getPyArrayObject(residualsData, NPY_DOUBLE);
+        PyArrayObject *cameraMasksDataArr = helper_getPyArrayObject(cameraMasksData, NPY_DOUBLE);
+        PyArrayObject *analogDataArr = helper_getPyArrayObject(analogData, NPY_DOUBLE);
+        _numpy_data(self, pointsDataArr, residualsDataArr, cameraMasksDataArr, analogDataArr);
+    }
+
     // Extend c3d class to get an easy accessor to data points
     PyObject * get_points(){
         std::vector<int> points;

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -513,17 +513,23 @@ void ezc3d::c3d::frame(
                 "Number of points in POINT:USED parameter must equal"
                 "the number of points sent in the frame");
 
-    // Can I delete this?
-    //    std::vector<std::string> labels(parameters().group("POINT")
-    //                                    .parameter("LABELS").valuesAsString());
-    //    for (size_t i=0; i<labels.size(); ++i)
-    //        try {
-    //            pointIdx(labels[i]);
-    //        } catch (std::invalid_argument) {
-    //            throw std::invalid_argument(
-    //                    "All the points in the frame must appear "
-    //                    "in the POINT:LABELS parameter");
-    //        }
+    std::vector<std::string> labels(parameters().group("POINT")
+                                .parameter("LABELS").valuesAsString());
+    try {
+        // Check if all the labels are in the actual LABELSX parameter
+        const std::vector<std::string> &namesParameter(pointNames());
+        for (size_t i=0; i<labels.size(); ++i){
+            for (size_t i = 0; i < namesParameter.size(); ++i){
+                if (!namesParameter[i].compare(labels[i])){
+                    break;
+                }
+            }
+        }
+    } catch (std::invalid_argument) {
+        throw std::invalid_argument(
+                "All the points in the frame must appear "
+                "in the POINT:LABELS parameter");
+    }
 
     if (f.points().nbPoints() > 0
             && parameters().group("POINT")

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -513,16 +513,17 @@ void ezc3d::c3d::frame(
                 "Number of points in POINT:USED parameter must equal"
                 "the number of points sent in the frame");
 
-    std::vector<std::string> labels(parameters().group("POINT")
-                                    .parameter("LABELS").valuesAsString());
-    for (size_t i=0; i<labels.size(); ++i)
-        try {
-            pointIdx(labels[i]);
-        } catch (std::invalid_argument) {
-            throw std::invalid_argument(
-                    "All the points in the frame must appear "
-                    "in the POINT:LABELS parameter");
-        }
+    // Can I delete this?
+    //    std::vector<std::string> labels(parameters().group("POINT")
+    //                                    .parameter("LABELS").valuesAsString());
+    //    for (size_t i=0; i<labels.size(); ++i)
+    //        try {
+    //            pointIdx(labels[i]);
+    //        } catch (std::invalid_argument) {
+    //            throw std::invalid_argument(
+    //                    "All the points in the frame must appear "
+    //                    "in the POINT:LABELS parameter");
+    //        }
 
     if (f.points().nbPoints() > 0
             && parameters().group("POINT")


### PR DESCRIPTION
This PR speeds up the `c3d.write()` call in python. This is done by 2 ways:

1. The filling of the `new_c3d`-object was moved from Python to C++
2. The Label-Check was impoved ( not by me, but by @pariterre )

The results in the following improvements on `c3d.write() on the example file `Cortex.c3d` on my machine:

| Method | Time in seconds |
|-|-|
| Original/Old | 5.2061723 |
| `new_c3d` filled in C++ | 2.2334236 |
| `new_c3d` filles in C++ and improved Label-Check | 0.4963968 |

So in this particular example we see an 10x speed improvement.

****************************************************

I don't know if the code changes will be covered by existing tests. They should be though, since writing to disk is no new functionality.

If I deviate from the coding style of the rest of the code base too much, please tell me how to improve.