### PR TITLE
Small Bug Fixes

### DIFF
--- a/include/ezc3d/DataStartInfo.h
+++ b/include/ezc3d/DataStartInfo.h
@@ -125,7 +125,7 @@ public:
 protected:
     bool m_hasParameterRotationsDataStart = false;  ///< If the rotations data start is set for the parameters
     std::streampos m_parameterRotationsDataStart;  ///< Position in the c3d to put the rotations start start in the parameters
-    DATA_TYPE m_parameterRotationsDataStartSize = DATA_TYPE::BYTE;  ///< The size of the value in the c3d file
+    DATA_TYPE m_parameterRotationsDataStartSize = DATA_TYPE::WORD;  ///< The size of the value in the c3d file
 
 public:
     ///

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     cmake_args=[
         '-DBUILD_EXAMPLE:BOOL=OFF',
         '-DBINDER_PYTHON3:BOOL=ON',
-        '-DCMAKE_INSTALL_BINDIR="ezc3d"',
-        '-DCMAKE_INSTALL_LIBDIR="ezc3d"'
+        '-DCMAKE_INSTALL_BINDIR=ezc3d',
+        '-DCMAKE_INSTALL_LIBDIR=ezc3d'
     ],
 )


### PR DESCRIPTION
Two small bug fixes, 

First: Changed rotations data start parameter from 8 bit BYTE to 16bit WORD.  Fixes issue when rotation datastart needs to have value greater than 255. 

Second: Removed extra quotes from setup.py which created non valid paths when building.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/250)
<!-- Reviewable:end -->
