### PR TITLE
Re-solves #264

### DIFF
--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -478,7 +478,7 @@ class c3d(C3dMapper):
                 if nb_analog_frames % nb_point_frames != 0:
                     raise ValueError("Number of frames of Points and Analogs should be a multiple of an integer")
             else:
-                if ~np.close(
+                if ~np.isclose(
                     nb_analog_frames * self._storage["parameters"]["POINT"]["RATE"]["value"][0],
                     nb_point_frames * self._storage["parameters"]["ANALOG"]["RATE"]["value"][0]
                 ):

--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -478,9 +478,9 @@ class c3d(C3dMapper):
                 if nb_analog_frames % nb_point_frames != 0:
                     raise ValueError("Number of frames of Points and Analogs should be a multiple of an integer")
             else:
-                if (
-                    nb_analog_frames * self._storage["parameters"]["POINT"]["RATE"]["value"][0]
-                    != nb_point_frames * self._storage["parameters"]["ANALOG"]["RATE"]["value"][0]
+                if ~np.close(
+                    nb_analog_frames * self._storage["parameters"]["POINT"]["RATE"]["value"][0],
+                    nb_point_frames * self._storage["parameters"]["ANALOG"]["RATE"]["value"][0]
                 ):
                     raise ValueError("Number of frames in the data set must match the analog rate X point frame")
 


### PR DESCRIPTION
This re-solves #264 which had been cancelled by commit ba50ee55aa1a4fcceb87460ec07fc03c3fc5365b

This is important if you need to support non-integer sample rates. Currently, the only way to make ezc3d to write analogs and points reliably is to specifically define the sampling rates as integers. Floats don't work.

While using floats for sampling rate may be weird (normally we set it as an int in the recording software), I can see value to support floats, for instance to synchronize two instruments that drifted over a common sampling rate that could be non-integer.

In my particular application (ktk), I need to generate c3ds from TimeSeries where the sampling rate is calculated dynamically based on a time vector. It will always be a float.

Anyway this PR fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/283)
<!-- Reviewable:end -->
