### PR TITLE
Fixed memory leak when using to_array() in python

### DIFF
--- a/binding/python3/ezc3d_python.i
+++ b/binding/python3/ezc3d_python.i
@@ -495,6 +495,7 @@ PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
         }
         PyObject* output = PyArray_SimpleNewFromData(nArraySize,arraySizes,NPY_DOUBLE, mat);
         PyArray_ENABLEFLAGS((PyArrayObject *)output, NPY_ARRAY_OWNDATA);
+        delete[] arraySizes;
         return output;
     };
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/315)
<!-- Reviewable:end -->
