### PR TITLE
Fix compiler and ubsan warnings

### DIFF
--- a/src/Analogs.cpp
+++ b/src/Analogs.cpp
@@ -50,7 +50,7 @@ const ezc3d::DataNS::AnalogsNS::SubFrame &
 ezc3d::DataNS::AnalogsNS::Analogs::subframe(size_t idx) const {
   try {
     return _subframe.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Analogs::subframe method is trying to access the subframe " +
         std::to_string(idx) + " while the maximum number of subframes is " +
@@ -62,7 +62,7 @@ ezc3d::DataNS::AnalogsNS::SubFrame &
 ezc3d::DataNS::AnalogsNS::Analogs::subframe(size_t idx) {
   try {
     return _subframe.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Analogs::subframe method is trying to access the subframe " +
         std::to_string(idx) + " while the maximum number of subframes is " +

--- a/src/AnalogsInfo.cpp
+++ b/src/AnalogsInfo.cpp
@@ -32,7 +32,6 @@ ezc3d::DataNS::AnalogsNS::Info::Info(const ezc3d::c3d &c3d)
   if (c3d.parameters().isGroup("SHADOW")) {
     // The SHADOW company did not respect the standard and put these values in
     // the ANALOG group So we have to assume some default values
-    size_t nbAnalogs = c3d.header().nbAnalogs();
     if (_scaleFactors.empty()) {
       for (size_t i = 0; i < c3d.header().nbAnalogs(); ++i)
         _scaleFactors.push_back(1.0);

--- a/src/AnalogsSubframe.cpp
+++ b/src/AnalogsSubframe.cpp
@@ -52,7 +52,7 @@ const ezc3d::DataNS::AnalogsNS::Channel &
 ezc3d::DataNS::AnalogsNS::SubFrame::channel(size_t idx) const {
   try {
     return _channels.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Subframe::channel method is trying to access the channel " +
         std::to_string(idx) + " while the maximum number of channels is " +
@@ -64,7 +64,7 @@ ezc3d::DataNS::AnalogsNS::Channel &
 ezc3d::DataNS::AnalogsNS::SubFrame::channel(size_t idx) {
   try {
     return _channels.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Subframe::channel method is trying to access the channel " +
         std::to_string(idx) + " while the maximum number of channels is " +

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -101,7 +101,7 @@ size_t ezc3d::DataNS::Data::nbFrames() const { return _frames.size(); }
 const ezc3d::DataNS::Frame &ezc3d::DataNS::Data::frame(size_t idx) const {
   try {
     return _frames.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Data::frame method is trying to access the frame " +
         std::to_string(idx) + " while the maximum number of frame is " +
@@ -112,7 +112,7 @@ const ezc3d::DataNS::Frame &ezc3d::DataNS::Data::frame(size_t idx) const {
 ezc3d::DataNS::Frame &ezc3d::DataNS::Data::frame(size_t idx) {
   try {
     return _frames.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Data::frame method is trying to access the frame " +
         std::to_string(idx) + " while the maximum number of frames is " +

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -148,7 +148,7 @@ bool ezc3d::ParametersNS::GroupNS::Group::isParameter(
   try {
     parameterIdx(parameterName);
     return true;
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument&) {
     return false;
   }
 }
@@ -166,7 +166,7 @@ const ezc3d::ParametersNS::GroupNS::Parameter &
 ezc3d::ParametersNS::GroupNS::Group::parameter(size_t idx) const {
   try {
     return _parameters.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Groups::parameter method is trying "
         "to access the parameter " +
@@ -179,7 +179,7 @@ ezc3d::ParametersNS::GroupNS::Parameter &
 ezc3d::ParametersNS::GroupNS::Group::parameter(size_t idx) {
   try {
     return _parameters.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Groups::parameter method is trying "
         "to access the parameter " +

--- a/src/Header.cpp
+++ b/src/Header.cpp
@@ -345,7 +345,7 @@ const std::vector<float> &ezc3d::Header::eventsTime() const {
 float ezc3d::Header::eventsTime(size_t idx) const {
   try {
     return _eventsTime.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Header::eventsTime method is trying to access the event " +
         std::to_string(idx) + " while the maximum number of events is " +
@@ -360,7 +360,7 @@ std::vector<size_t> ezc3d::Header::eventsDisplay() const {
 size_t ezc3d::Header::eventsDisplay(size_t idx) const {
   try {
     return _eventsDisplay.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range("Header::eventsDisplay method is trying "
                             "to access the event " +
                             std::to_string(idx) +
@@ -376,7 +376,7 @@ const std::vector<std::string> &ezc3d::Header::eventsLabel() const {
 const std::string &ezc3d::Header::eventsLabel(size_t idx) const {
   try {
     return _eventsLabel.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Header::eventsLabel method is trying to access the event " +
         std::to_string(idx) + " while the maximum number of events is " +

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -503,7 +503,7 @@ bool ezc3d::ParametersNS::Parameters::isGroup(
   try {
     groupIdx(groupName);
     return true;
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument&) {
     return false;
   }
 }
@@ -521,7 +521,7 @@ const ezc3d::ParametersNS::GroupNS::Group &
 ezc3d::ParametersNS::Parameters::group(size_t idx) const {
   try {
     return _groups.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Parameters::group method is trying to access the group " +
         std::to_string(idx) + " while the maximum number of groups is " +
@@ -533,7 +533,7 @@ ezc3d::ParametersNS::GroupNS::Group &
 ezc3d::ParametersNS::Parameters::group(size_t idx) {
   try {
     return _groups.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Parameters::group method is trying to access the group " +
         std::to_string(idx) + " while the maximum number of groups is " +

--- a/src/Points.cpp
+++ b/src/Points.cpp
@@ -49,7 +49,7 @@ const ezc3d::DataNS::Points3dNS::Point &
 ezc3d::DataNS::Points3dNS::Points::point(size_t idx) const {
   try {
     return _points.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Points::point method is trying to access the point " +
         std::to_string(idx) + " while the maximum number of points is " +
@@ -61,7 +61,7 @@ ezc3d::DataNS::Points3dNS::Point &
 ezc3d::DataNS::Points3dNS::Points::point(size_t idx) {
   try {
     return _points.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Points::point method is trying to access the point " +
         std::to_string(idx) + " while the maximum number of points is " +

--- a/src/Rotations.cpp
+++ b/src/Rotations.cpp
@@ -57,7 +57,7 @@ const ezc3d::DataNS::RotationNS::SubFrame &
 ezc3d::DataNS::RotationNS::Rotations::subframe(size_t idx) const {
   try {
     return _subframe.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Analogs::subframe method is trying to access the subframe " +
         std::to_string(idx) + " while the maximum number of subframes is " +
@@ -69,7 +69,7 @@ ezc3d::DataNS::RotationNS::SubFrame &
 ezc3d::DataNS::RotationNS::Rotations::subframe(size_t idx) {
   try {
     return _subframe.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Analogs::subframe method is trying to access the subframe " +
         std::to_string(idx) + " while the maximum number of subframes is " +

--- a/src/RotationsSubframe.cpp
+++ b/src/RotationsSubframe.cpp
@@ -54,7 +54,7 @@ const ezc3d::DataNS::RotationNS::Rotation &
 ezc3d::DataNS::RotationNS::SubFrame::rotation(size_t idx) const {
   try {
     return _rotations.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Subframe::rotation method is trying to access the rotation " +
         std::to_string(idx) + " while the maximum number of rotations is " +
@@ -66,7 +66,7 @@ ezc3d::DataNS::RotationNS::Rotation &
 ezc3d::DataNS::RotationNS::SubFrame::rotation(size_t idx) {
   try {
     return _rotations.at(idx);
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     throw std::out_of_range(
         "Subframe::rotation method is trying to access the rotation " +
         std::to_string(idx) + " while the maximum number of rotations is " +

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -610,7 +610,7 @@ void ezc3d::c3d::frame(const ezc3d::DataNS::Frame &f, size_t idx,
 void ezc3d::c3d::frames(const std::vector<ezc3d::DataNS::Frame> frames,
                         size_t firstFrameidx) {
 
-  for (int i = 0; i < frames.size(); i++) {
+  for (size_t i = 0; i < frames.size(); i++) {
     // Only performs internal updates on the first and last frames
     bool skipInternalUpdates = i > 0 && i < frames.size() - 1;
     frame(frames[i], firstFrameidx == SIZE_MAX ? SIZE_MAX : firstFrameidx + i,

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -134,11 +134,13 @@ void ezc3d::c3d::readFile(std::fstream &file, unsigned int nByteToRead,
 
 unsigned int ezc3d::c3d::hex2uint(const std::vector<char> &val,
                                   unsigned int len) {
-  int ret(0);
-  for (unsigned int i = 0; i < len; i++)
-    ret |= static_cast<int>(static_cast<unsigned char>(val[i])) *
-           static_cast<int>(pow(0x100, i));
-  return static_cast<unsigned int>(ret);
+  unsigned int ret(0);
+  // Discard any extra bytes to avoid overflow of int
+  unsigned int max_bytes = std::min(len, 4u);
+  for (unsigned int i = 0; i < max_bytes; ++i)
+    ret |= static_cast<unsigned int>(
+      static_cast<unsigned char>(val[i])) << (8 * i);
+  return ret;
 }
 
 int ezc3d::c3d::hex2int(const std::vector<char> &val, unsigned int len) {
@@ -146,9 +148,11 @@ int ezc3d::c3d::hex2int(const std::vector<char> &val, unsigned int len) {
 
   // convert to signed int
   // Find max int value
+  // Discard any extra bytes to avoid overflow of int
   unsigned int max(0);
-  for (unsigned int i = 0; i < len; ++i)
-    max |= 0xFF * static_cast<unsigned int>(pow(0x100, i));
+  unsigned int max_bytes = std::min(len, 4u);
+  for (unsigned int i = 0; i < max_bytes; ++i)
+    max |= 0xFFu << (8 * i);
 
   // If the value is over uint_max / 2 then it is a negative number
   int out;

--- a/src/ezc3d.cpp
+++ b/src/ezc3d.cpp
@@ -484,7 +484,7 @@ void ezc3d::c3d::setGroupMetadata(const std::string &groupName,
   size_t idx;
   try {
     idx = parameters().groupIdx(groupName);
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument&) {
     _parameters->group(ezc3d::ParametersNS::GroupNS::Group(groupName));
     idx = parameters().groupIdx(groupName);
   }
@@ -506,7 +506,7 @@ void ezc3d::c3d::parameter(const std::string &groupName,
   size_t idx;
   try {
     idx = parameters().groupIdx(groupName);
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument&) {
     _parameters->group(ezc3d::ParametersNS::GroupNS::Group(groupName));
     idx = parameters().groupIdx(groupName);
   }
@@ -573,7 +573,7 @@ void ezc3d::c3d::frame(const ezc3d::DataNS::Frame &f, size_t idx,
         }
       }
     }
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument&) {
     throw std::invalid_argument("All the points in the frame must appear "
                                 "in the POINT:LABELS parameter");
   }


### PR DESCRIPTION
While working on the R implementation of ezc3d I found some compiler and ubsan warnings generated by the C++ source code. I tried to remove them by making the following modification:

- Avoid integer overflow in `hex2uint` and `hex2int` by disregarding extra bytes. Also using bit shifting which should be faster and safer (https://github.com/pyomeca/ezc3d/commit/0f99702610e388e9ad2acd09d57bdce188a3585b)
- Catch by reference not by value in various functions (https://github.com/pyomeca/ezc3d/commit/81b7345de74cb122f3f42d810f8d71000dba6f19)
- Remove an unused variable in `ezc3d::DataNS::AnalogsNS::Info::Info` (https://github.com/pyomeca/ezc3d/commit/61945bb28cd4f4c2ef6713ce7659082b4aa46de9)
- Fix correct comparison of signed and unsigned integers in `ezc3d::c3d::frames` (https://github.com/pyomeca/ezc3d/commit/86f2bf67304db08d71571bb6bd2adffd60086312)

I have yet to get used to the test suite, so I have not tested the modifications so far (apart from the R implementation, where I could remove the warnings and the code still works as intended).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/359)
<!-- Reviewable:end -->
