### PR TITLE
Update link to R package

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ pf_0['Tz']                  # Moment at center of pressure data
 ## R
 R (<https://www.r-project.org/about.html>) is a programming language popular for statistical analyses and data visualization.
 
-The `c3dr` package (<https://github.com/smnnlt/ezc3d>) provides an R interface for EZC3D. For more details visit the package repository.
+The `c3dr` package (<https://github.com/ropensci/c3dr>) provides an R interface for EZC3D. For more details visit the package repository.
 
 # How to contribute
 You are very welcome to contribute to the project! There are two main ways to contribute. 


### PR DESCRIPTION
The R interface for ezc3d has been peer-reviewed and transferred to a new repository of the rOpenSci organization (https://github.com/ropensci/c3dr).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/360)
<!-- Reviewable:end -->
