### PR TITLE
Pre‑resize _points vector in Points constructor

### DIFF
--- a/src/Points.cpp
+++ b/src/Points.cpp
@@ -22,6 +22,7 @@ ezc3d::DataNS::Points3dNS::Points::Points(size_t nbPoints) {
 ezc3d::DataNS::Points3dNS::Points::Points(
     ezc3d::c3d &c3d, std::fstream &file,
     const ezc3d::DataNS::Points3dNS::Info &info) {
+  _points.resize(c3d.header().nb3dPoints());
   for (size_t i = 0; i < c3d.header().nb3dPoints(); ++i) {
     ezc3d::DataNS::Points3dNS::Point pt(c3d, file, info);
     point(pt, i);


### PR DESCRIPTION
This PR addresses #369.

I think I should add a test case about that but I'm not sure how to do so. I don't find any benchmark in the test project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/370)
<!-- Reviewable:end -->
