### PR TITLE
Remove OSX ARM64 condition from MATLAB install

### DIFF
--- a/.github/workflows/publish_matlab_binaries.yml
+++ b/.github/workflows/publish_matlab_binaries.yml
@@ -58,7 +58,6 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with: 
           cache: true
-        if: matrix.label != 'osx-arm64' 
 
       - name: Build ezc3d on UNIX
         run: |


### PR DESCRIPTION
Remove conditional check for OSX ARM64 in MATLAB setup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/381)
<!-- Reviewable:end -->
