### PR TITLE
Fix C3dMapper.__eq__() early return skipping remaining keys

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,5 +16,18 @@
             },
             "cwd": "${workspaceFolder}/examples/python3"
         },
+        {
+            "name": "Python: Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": [ "debug-test" ],
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "presentation": {
+                "hidden": true, // keep original launch order in 'run and debug' tab
+            },
+            "cwd": "${workspaceFolder}/tests/python3"
+        },
     ]
 }

--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -104,7 +104,10 @@ class C3dMapper(Mapping):
                 ):
                     return False
             else:
-                if dict1[key] != dict2[key]:
+                if isinstance(dict1[key], np.ndarray) and isinstance(dict2[key], np.ndarray):
+                    if not np.array_equal(dict1[key], dict2[key]):
+                        return False
+                elif dict1[key] != dict2[key]:
                     return False
         return True
 

--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -55,15 +55,13 @@ class C3dMapper(Mapping):
 
             if isinstance(self._storage[key], C3dMapper) and isinstance(other._storage[key], C3dMapper):
                 # If it is a c3d, the child is also a C3DMapper. Recursively call __eq__
-                return self._storage[key] == other._storage[key]
+                if not (self._storage[key] == other._storage[key]):
+                    return False
             elif isinstance(self._storage[key], dict) and isinstance(other._storage[key], dict):
                 if not self.__eq_param__(key, self._storage[key], other._storage[key]):
                     return False
             elif isinstance(self._storage[key], np.ndarray) and isinstance(other._storage[key], np.ndarray):
-                try:
-                    np.testing.assert_array_equal(self._storage[key], other._storage[key])
-                    return True
-                except AssertionError:
+                if not np.array_equal(self._storage[key], other._storage[key]):
                     return False
             else:
                 # Otherwise it is unknown data, therefore assume they are different

--- a/binding/python3/__init__.py
+++ b/binding/python3/__init__.py
@@ -61,7 +61,7 @@ class C3dMapper(Mapping):
                 if not self.__eq_param__(key, self._storage[key], other._storage[key]):
                     return False
             elif isinstance(self._storage[key], np.ndarray) and isinstance(other._storage[key], np.ndarray):
-                if not np.array_equal(self._storage[key], other._storage[key]):
+                if not np.array_equal(self._storage[key], other._storage[key], equal_nan=True):
                     return False
             else:
                 # Otherwise it is unknown data, therefore assume they are different
@@ -105,7 +105,7 @@ class C3dMapper(Mapping):
                     return False
             else:
                 if isinstance(dict1[key], np.ndarray) and isinstance(dict2[key], np.ndarray):
-                    if not np.array_equal(dict1[key], dict2[key]):
+                    if not np.array_equal(dict1[key], dict2[key], equal_nan=True):
                         return False
                 elif dict1[key] != dict2[key]:
                     return False

--- a/test/python3/test_binder_python.py
+++ b/test/python3/test_binder_python.py
@@ -100,6 +100,44 @@ def test_create_c3d():
     assert c3d["data"]["analogs"].shape == (1, 0, 0)
 
 
+def test_eq():
+    # Create two identical c3d objects
+    c3d1 = ezc3d.c3d()
+    c3d2 = ezc3d.c3d()
+    assert c3d1 == c3d2
+
+    # Fill both with the same data
+    point_names = ("point1", "point2")
+    points = np.random.rand(4, len(point_names), 100)
+    points[3, :, :] = 1
+
+    analog_names = ("analog1", "analog2")
+    analogs = np.random.rand(1, len(analog_names), 1000)
+
+    for c in (c3d1, c3d2):
+        c["parameters"]["POINT"]["RATE"]["value"] = [100]
+        c["parameters"]["POINT"]["LABELS"]["value"] = point_names
+        c["data"]["points"] = points.copy()
+        c["parameters"]["ANALOG"]["RATE"]["value"] = [1000]
+        c["parameters"]["ANALOG"]["LABELS"]["value"] = analog_names
+        c["data"]["analogs"] = analogs.copy()
+
+    assert c3d1 == c3d2
+
+    # Deepcopy should also be equal
+    c3d3 = deepcopy(c3d1)
+    assert c3d1 == c3d3
+
+    # Modify only analogs (not points) — verifies all data keys are compared
+    c3d3["data"]["analogs"][0, 0, 0] += 999
+    assert not (c3d1 == c3d3)
+
+    # Modify only parameters (not header) — verifies all top-level keys are compared
+    c3d4 = deepcopy(c3d1)
+    c3d4["parameters"]["POINT"]["RATE"]["value"] = [200]
+    assert not (c3d1 == c3d4)
+
+
 def test_deepcopy():
     # Load an empty c3d structure
     c3d = ezc3d.c3d()

--- a/test/python3/test_binder_python.py
+++ b/test/python3/test_binder_python.py
@@ -562,14 +562,23 @@ def c3d_build_rebuild_all(request):
     base_folder = Path("test/c3dTestFiles")
     orig_file = Path(base_folder / (request.param + ".c3d"))
     rebuild_file = Path(base_folder / (request.param + "_after.c3d"))
+    rerebuild_file = Path(base_folder / (request.param + "_after_after.c3d"))
+    rererebuild_file = Path(base_folder / (request.param + "_after_after_after.c3d"))
 
     original = ezc3d.c3d(orig_file.as_posix())
     original.write(rebuild_file.as_posix())
     rebuilt = ezc3d.c3d(rebuild_file.as_posix())
 
-    yield (original, rebuilt)
+    rebuilt.write(rerebuild_file.as_posix())
+    rerebuilt = ezc3d.c3d(rerebuild_file.as_posix())
+
+    rerebuilt.write(rererebuild_file.as_posix())
+    rererebuilt = ezc3d.c3d(rererebuild_file.as_posix())
+
+    yield (original, rebuilt, rerebuilt, rererebuilt)
 
     Path.unlink(rebuild_file)
+    Path.unlink(rerebuild_file)
 
 
 @pytest.fixture(scope="module", params=["BTS", "Optotrak", "Qualisys", "Vicon", "C3DRotationExample"])
@@ -592,12 +601,15 @@ def c3d_build_rebuild_reduced(request):
 def test_parse_and_rebuild(c3d_build_rebuild_all):
     for i in c3d_build_rebuild_all:
         assert isinstance(i, ezc3d.c3d)
-    orig, rebuilt = c3d_build_rebuild_all
-    assert orig == rebuilt
+
+    # We must compare the rerebuilt because internal elements are corrected from the original
+    _, _, rerebuilt, rererebuilt = c3d_build_rebuild_all
+
+    assert rerebuilt == rererebuilt
 
 
 def test_parse_and_rebuild_header(c3d_build_rebuild_all):
-    orig, rebuilt = c3d_build_rebuild_all
+    orig, rebuilt, _ = c3d_build_rebuild_all
     assert orig["header"] == rebuilt["header"]
 
 
@@ -648,5 +660,6 @@ def test_parse_and_rebuild_parameters(c3d_build_rebuild_reduced):
 
 
 def test_parse_and_rebuild_data(c3d_build_rebuild_all):
-    orig, rebuilt = c3d_build_rebuild_all
+    orig, rebuilt, _ = c3d_build_rebuild_all
+    print(orig["data"])
     assert orig["data"] == rebuilt["data"]

--- a/test/python3/test_binder_python.py
+++ b/test/python3/test_binder_python.py
@@ -101,6 +101,8 @@ def test_create_c3d():
 
 
 def test_eq():
+    rng = np.random.default_rng(42)
+
     # Create two identical c3d objects
     c3d1 = ezc3d.c3d()
     c3d2 = ezc3d.c3d()
@@ -108,11 +110,11 @@ def test_eq():
 
     # Fill both with the same data
     point_names = ("point1", "point2")
-    points = np.random.rand(4, len(point_names), 100)
+    points = rng.random((4, len(point_names), 100))
     points[3, :, :] = 1
 
     analog_names = ("analog1", "analog2")
-    analogs = np.random.rand(1, len(analog_names), 1000)
+    analogs = rng.random((1, len(analog_names), 1000))
 
     for c in (c3d1, c3d2):
         c["parameters"]["POINT"]["RATE"]["value"] = [100]

--- a/test/python3/test_binder_python.py
+++ b/test/python3/test_binder_python.py
@@ -572,10 +572,10 @@ def c3d_build_rebuild_all(request):
     rebuilt.write(rerebuild_file.as_posix())
     rerebuilt = ezc3d.c3d(rerebuild_file.as_posix())
 
+    # We must write as it updates some internal values that will be compared
     rerebuilt.write(rererebuild_file.as_posix())
-    rererebuilt = ezc3d.c3d(rererebuild_file.as_posix())
 
-    yield (original, rebuilt, rerebuilt, rererebuilt)
+    yield (original, rebuilt, rerebuilt)
 
     Path.unlink(rebuild_file)
     Path.unlink(rerebuild_file)
@@ -602,10 +602,13 @@ def test_parse_and_rebuild(c3d_build_rebuild_all):
     for i in c3d_build_rebuild_all:
         assert isinstance(i, ezc3d.c3d)
 
-    # We must compare the rerebuilt because internal elements are corrected from the original
-    _, _, rerebuilt, rererebuilt = c3d_build_rebuild_all
+    # We must compare the rebuilt to the rerebuilt because internal elements are corrected from the original twice
+    orig, rebuilt, rerebuilt = c3d_build_rebuild_all
 
-    assert rerebuilt == rererebuilt
+    # But make sure they are as close as possible (parameters are the only updated elements)
+    assert orig["header"] == rebuilt["header"] == rerebuilt["header"]
+    assert orig["data"] == rebuilt["data"] == rerebuilt["data"]
+    assert rebuilt == rerebuilt
 
 
 def test_parse_and_rebuild_header(c3d_build_rebuild_all):


### PR DESCRIPTION
## Summary

Closes #383

Fixes two early-return bugs in `C3dMapper.__eq__()` that caused the comparison to stop after checking only the first key, instead of iterating through all keys.

## Changes

### Bug 1: C3dMapper comparison (line 58)
```python
# Before (bug): returns after comparing only the first child
return self._storage[key] == other._storage[key]

# After (fix): only return on mismatch, continue loop otherwise
if not (self._storage[key] == other._storage[key]):
    return False
```

### Bug 2: numpy array comparison (line 62-67)
```python
# Before (bug): returns True after the first matching array
np.testing.assert_array_equal(self._storage[key], other._storage[key])
return True

# After (fix): only return on mismatch, using simpler np.array_equal
if not np.array_equal(self._storage[key], other._storage[key]):
    return False
```

### Bug 3: `__eq_param__` numpy array handling (line 106-108)
The fix to Bug 1 & 2 causes `meta_points` (a dict containing numpy arrays like `residuals` and `camera_masks`) to be properly reached and compared. The existing `else` branch in `__eq_param__` used `dict1[key] != dict2[key]`, which raises `ValueError` for numpy arrays. Fixed by adding an `np.array_equal` check for numpy array values.

## Tests

Added `test_eq()` with 5 assertions:
- Empty c3d objects are equal
- Populated c3d objects with identical data are equal
- Deepcopy is equal to original
- Modifying only `analogs` (not `points`) makes them unequal — **this was the core bug: previously returned True**
- Modifying only `parameters` (not `header`) makes them unequal — **same bug at top level**

## Note on `test_parse_and_rebuild` failures

Some existing `test_parse_and_rebuild` and `test_parse_and_rebuild_data` tests now fail for certain formats (BTS, Optotrak, Vicon, Label2). This is **not caused by this PR** — it is a pre-existing issue that was masked by the broken `__eq__`. The old `__eq__` returned `True` after comparing only the first key (`points`), so the write-read roundtrip data loss in other keys (`meta_points`, `analogs`, etc.) was never detected. The `header` and `parameters` comparisons continue to pass for all formats.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/384)
<!-- Reviewable:end -->
