### PR TITLE
Fix memory leak in Python bindings

### DIFF
--- a/binding/python3/ezc3d_python.i
+++ b/binding/python3/ezc3d_python.i
@@ -210,7 +210,7 @@ PyObject * _get_rotations(
 %}
 
 %inline %{
-PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
+PyArrayObject *helper_getPyArrayObject( PyObject *input, int type, int *conversion_done) {
   PyArrayObject *obj;
 
   if (PyArray_Check( input )) {
@@ -220,8 +220,7 @@ PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
       PyErr_SetString( PyExc_TypeError, "not algned or not in machine byte order" );
       return NULL;
     }
-    int conversion_done = 0;
-    obj = (PyArrayObject *) obj_to_array_allow_conversion( input, type, &conversion_done );
+    obj = (PyArrayObject *) obj_to_array_allow_conversion( input, type, conversion_done );
     if (!obj) return NULL;
   } else {
     PyErr_SetString( PyExc_TypeError, "not an array" );
@@ -353,14 +352,26 @@ PyArrayObject *helper_getPyArrayObject( PyObject *input, int type) {
             PyObject *analogData,
             PyObject *rotationsData
         ){
-        PyArrayObject *pointsDataArr = helper_getPyArrayObject(pointsData, NPY_DOUBLE);
-        PyArrayObject *residualsDataArr = helper_getPyArrayObject(residualsData, NPY_DOUBLE);
-        PyArrayObject *cameraMasksDataArr = helper_getPyArrayObject(cameraMasksData, NPY_DOUBLE);
-        PyArrayObject *analogDataArr = helper_getPyArrayObject(analogData, NPY_DOUBLE);
+        int converted[5] = {0,0,0,0,0};
+        PyArrayObject *pointsDataArr = helper_getPyArrayObject(pointsData, NPY_DOUBLE, &converted[0]);
+        PyArrayObject *residualsDataArr = helper_getPyArrayObject(residualsData, NPY_DOUBLE, &converted[1]);
+        PyArrayObject *cameraMasksDataArr = helper_getPyArrayObject(cameraMasksData, NPY_DOUBLE, &converted[2]);
+        PyArrayObject *analogDataArr = helper_getPyArrayObject(analogData, NPY_DOUBLE, &converted[3]);
         PyArrayObject *rotationDataArr = nullptr;
         if (rotationsData != Py_None)
-            rotationDataArr = helper_getPyArrayObject(rotationsData, NPY_DOUBLE);
+            rotationDataArr = helper_getPyArrayObject(rotationsData, NPY_DOUBLE, &converted[4]);
+
         _import_numpy_data(self, pointsDataArr, residualsDataArr, cameraMasksDataArr, analogDataArr, rotationDataArr);
+
+        // converted -> copied to new array; need to decrement ref counter
+        if (converted[0]) Py_DECREF(pointsDataArr);
+        if (converted[1]) Py_DECREF(residualsDataArr);
+        if (converted[2]) Py_DECREF(cameraMasksDataArr);
+        if (converted[3]) Py_DECREF(analogDataArr);
+        if (rotationsData != Py_None)
+        {
+            if (converted[4]) Py_DECREF(rotationDataArr);
+        }
     }
 
     // Extend c3d class to get an easy accessor to data points


### PR DESCRIPTION
The Python bindings have a memory leak. 
The `helper_getPyArrayObject` could create copies of numpy arrays, that were not deleted after usage (i.e. the reference counter was never decremented, leading Python to hang on to the objects).
One example case, where this can become critical, is writing many files. 

This can be reproduces with this simple script:

```python
import tracemalloc
tracemalloc.start()
import ezc3d

for _ in range(40):
    c3d = ezc3d.c3d(r"D:\Download\Cortex.c3d")
    c3d.write('test_del_me.c3d')

snapshot = tracemalloc.take_snapshot()
top_stats = snapshot.statistics("lineno")

for stat in top_stats[:10]:
    print(stat)
```

which will print sth. like the following, showing a large RAM usage from non-destructed objects


> **ezc3d\.venv\Lib\site-packages\ezc3d\ezc3d.py:1720: size=769 MiB, count=82, average=9604 KiB**
> \<frozen importlib._bootstrap_external\>:757: size=4053 KiB, count=27913, average=149 B
> \<frozen importlib._bootstrap\>:488: size=1549 KiB, count=16602, average=96 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\inspect.py:909: size=249 KiB, count=329, average=775 B
> \<frozen abc\>:106: size=98.8 KiB, count=387, average=261 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\functools.py:52: size=61.4 KiB, count=328, average=192 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\functools.py:56: size=51.7 KiB, count=256, average=207 B
> ezc3d\.venv\Lib\site-packages\numpy\_utils\_inspect.py:79: size=48.5 KiB, count=864, average=57 B
> ezc3d\.venv\Lib\site-packages\numpy\_core\overrides.py:164: size=34.1 KiB, count=551, average=63 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\collections\__init__.py:508: size=32.6 KiB, count=148, average=226 B
> 

after this fix, the same would read


> \<frozen importlib._bootstrap_external\>:757: size=4053 KiB, count=27914, average=149 B
> \<frozen importlib._bootstrap\>:488: size=1549 KiB, count=16602, average=96 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\inspect.py:909: size=249 KiB, count=329, average=775 B
> \<frozen abc\>:106: size=98.8 KiB, count=387, average=261 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\functools.py:52: size=61.4 KiB, count=328, average=192 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\functools.py:56: size=51.7 KiB, count=256, average=207 B
> ezc3d\.venv\Lib\site-packages\numpy\_utils\_inspect.py:79: size=48.5 KiB, count=864, average=57 B
> ezc3d\.venv\Lib\site-packages\numpy\_core\overrides.py:164: size=34.1 KiB, count=551, average=63 B
> uv\python\cpython-3.12.9-windows-x86_64-none\Lib\collections\__init__.py:508: size=32.6 KiB, count=148, average=226 B
> ezc3d\.venv\Lib\site-packages\numpy\_core\overrides.py:28: size=31.2 KiB, count=9, average=3554 B

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/ezc3d/404)
<!-- Reviewable:end -->
